### PR TITLE
feat(styles):  CORE-109 добавил скейлинг по дефолту

### DIFF
--- a/packages/core-design/src/styles/normalize.ts
+++ b/packages/core-design/src/styles/normalize.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/core'
 
-const normalize = css`
+const normalize = theme => css`
   .js-focus-visible :focus:not(.focus-visible) {
     outline: none;
   }
@@ -14,6 +14,19 @@ const normalize = css`
     margin: 0;
     padding: 0;
   }
+
+  ${theme.breakpoints.mobile.all} {
+    html {
+      font-size: 4.44444444444444444444444444444444vw !important;
+    }
+  }
+
+  ${theme.breakpoints.tablet.s} {
+    html {
+      font-size: 1.5625vw !important;
+    }
+  }
+
   main {
     display: block;
   }


### PR DESCRIPTION
BREAKING CHANGE: Система скелинга должна была быть установлена по дефолту
(работает на разрешния меньше 1280), но про неё забыли, исправляю
эту историческую несправедливость

## Задача
- ссылка на jira: https://jira.csssr.io/browse/CORE-109
- стенд: http://feat-core-109-scaling-styles.cre-design.csssr.ru

## Чек-лист
- [ ] Указаны ревьюеры
- [x] Код работает полностью согласно описанию задачи
- [x] eslint и dev-консоль браузера без ошибок

## Дополнительно
* документация по добавленным библиотекам
* скриншоты
