### PR TITLE
chore: CORE-100 добавляет хак в экшен autopublish

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: reattach HEAD
+        run: |
+          git checkout "${GITHUB_REF:11}"
+
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
actions/checkout@v1 чекаутится в точную копию вашей репы с detached head
что бы экшн не валился на шаге "Publish new version if required"
нужно ["reattach'уть HEAD"](https://github.com/actions/checkout/issues/6)

## Задача
- ссылка на jira: https://jira.csssr.io/browse/CORE-100
- стенд: http://chore-core-100-checkout-detached-head-fix.cre-design.csssr.ru

## Чек-лист
- [x] Указаны ревьюеры
- [x] Код работает полностью согласно описанию задачи
- [x] eslint и dev-консоль браузера без ошибок
